### PR TITLE
delete an unnecessary print in geometry.extract()

### DIFF
--- a/pyjeo/modules/geometry.py
+++ b/pyjeo/modules/geometry.py
@@ -496,7 +496,6 @@ def extract(jvec,
                 bandname = [
                     't'+str(ifile) for ifile in range(0, len(jim._jipjimlist))]
             kwargs.update({'bandname': bandname})
-            print(bandname)
 
             avect = jim._jipjimlist.extractOgr(jvec._jipjimvect,
                                                kwargs)


### PR DESCRIPTION
This `print` itself without description does not bring any useful message to the user